### PR TITLE
Fix check for other Spectrum mods

### DIFF
--- a/paperback.lua
+++ b/paperback.lua
@@ -69,7 +69,11 @@ if PB_UTIL.config.suits_enabled then
   PB_UTIL.register_items(PB_UTIL.ENABLED_SUITS, "content/suit")
 
   -- Register Spectrum poker hand some other Spectrum mods are not installed
-  if not (next(SMODS.find_mod('Bunco') or next(SMODS.find_mod("SixSuits") or next(SMODS.find_mod("SpectrumFramework"))))) then
+  if not (
+    next(SMODS.find_mod('Bunco'))
+    or next(SMODS.find_mod("SixSuits"))
+    or next(SMODS.find_mod("SpectrumFramework"))
+    ) then
     PB_UTIL.register_items(PB_UTIL.ENABLED_POKER_HANDS, "content/pokerhand")
     PB_UTIL.register_items(PB_UTIL.ENABLED_PLANETS, "content/planet")
   end


### PR DESCRIPTION
Parentheses were in the wrong place, so the check was delivering incorrect answers.