### PR TITLE
Implemented "The Wonder of You" joker

### DIFF
--- a/content/joker/the_wonder_of_you.lua
+++ b/content/joker/the_wonder_of_you.lua
@@ -1,0 +1,42 @@
+SMODS.Joker {
+  key = "the_wonder_of_you",
+  rarity = 3,
+  pos = { x = 18, y = 4 },
+  atlas = 'jokers_atlas',
+  cost = 9,
+  blueprint_compat = true,
+  eternal_compat = true,
+  perishable_compat = true,
+
+  calculate = function(self, card, context)
+    --Check if the joker to the right has a probability roll
+    if context.pseudorandom_result and not context.result and context.trigger_obj then
+      if context.trigger_obj.config and context.trigger_obj.config.center and context.trigger_obj.config.center.set == 'Joker' then
+        local wonder_Pos = nil
+        local adjacent_Pos = nil
+        for i = 1, #G.jokers.cards do
+          if G.jokers.cards[i] == card then
+            wonder_Pos = i
+          end
+          if G.jokers.cards[i] == context.trigger_obj then
+            adjacent_Pos = i
+          end
+        end
+
+        -- Only activate if the failed joker is to the right of WOU
+        if wonder_Pos and adjacent_Pos and adjacent_Pos == wonder_Pos + 1 then
+          if G.hand.cards and #G.hand.cards > 0 then
+            for i = #G.hand.cards, 1, -1 do
+              if not G.hand.cards[i].destroyed then
+                SMODS.destroy_cards(G.hand.cards[i])
+                return {
+                  message = localize('paperback_destroyed_ex')
+                }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+}

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1392,11 +1392,20 @@ return {
       },
       j_paperback_der_fluschutze = {
         name = "Der Fluschütze",
-        text = { 
+        text = {
           "If {C:attention}first{} played hand of round",
           "was a single {C:attention}face{} card, destroy it",
           "and give this joker {X:mult,C:white}X#1#{} Mult",
           "{C:inactive}(Currently {X:mult,C:white}X#2#{} {C:inactive}Mult)"
+        }
+      },
+      j_paperback_the_wonder_of_you = {
+        name = "The Wonder of You",
+        text = {
+          "When the joker to the {C:attention}right{}",
+          "fails a {C:green}probability{} check,",
+          "the {C:attention}rightmost{} card held",
+          "in hand is {C:attention}destroyed{}"
         }
       },
       j_paperback_cakepop = {

--- a/utilities/definitions.lua
+++ b/utilities/definitions.lua
@@ -242,6 +242,7 @@ PB_UTIL.ENABLED_JOKERS = {
   "autumn_leaves",
   "river",
   "evergreens",
+  "the_wonder_of_you",
   "backpack",
   "mexican_train",
   "chocolate_joker",


### PR DESCRIPTION
## Summary
Adds "The Wonder of You" joker that destroys the rightmost card in hand when a joker to the right fails a probability check.
Uses SMODS new probability methods.

## Testing
Tested with Bloodstone during implementation and then with almost all jokers with probability effects at the end of implementation. 