### PR TITLE
Implemented Shopkeep

### DIFF
--- a/content/joker/shopkeep.lua
+++ b/content/joker/shopkeep.lua
@@ -1,0 +1,45 @@
+SMODS.Joker {
+  key = "shopkeep",
+  config = {
+    extra = {
+      count = 0,
+      blueprint_count = 0
+    }
+  },
+  rarity = 3,
+  pos = { x = 15, y = 7 },
+  atlas = 'jokers_atlas',
+  cost = 10,
+  unlocked = false,
+  blueprint_compat = true,
+  eternal_compat = true,
+
+  loc_vars = function(self, info_queue, card)
+    info_queue[#info_queue + 1] = G.P_TAGS.tag_coupon
+    info_queue[#info_queue + 1] = G.P_TAGS.tag_voucher
+  end,
+
+  check_for_unlock = function(self, args)
+    if args.type == 'round_spend_money' and to_number(args.round_spend_money) >= 50 then
+      unlock_card(self)
+    end
+  end,
+
+  calculate = function(self, card, context)
+    if context.first_hand_drawn and not context.blueprint then
+      card.ability.extra.count = card.ability.extra.count + 1
+    end
+
+    if context.end_of_round and context.main_eval then
+      if card.ability.extra.count > 0 and card.ability.extra.count % 2 == 0 then
+        PB_UTIL.add_tag('tag_coupon')
+        card:juice_up()
+      end
+    end
+
+    if context.end_of_round and G.GAME.blind.boss and context.main_eval then
+      PB_UTIL.add_tag('tag_voucher')
+      card:juice_up()
+    end
+  end
+}

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1464,6 +1464,17 @@ return {
           "of round is played"
         }
       },
+      j_paperback_shopkeep = {
+        name = "Shopkeep",
+        text = {
+          "Earn a {C:attention}Coupon Tag{} every other",
+          "blind, after defeating a {C:attention}Boss{}",
+          "{C:attention}Blind{}, earn a {C:attention}Voucher Tag{}"
+        },
+        unlock = {
+          "Spend {C:money}$50{} in one shop"
+        }
+      },
       j_paperback_cakepop = {
         name = "Cakepop",
         text = {

--- a/utilities/definitions.lua
+++ b/utilities/definitions.lua
@@ -239,7 +239,7 @@ PB_UTIL.ENABLED_JOKERS = {
   "prince_of_darkness",
   "giga_size",
   "jester_of_nihil",
-  -- "shopkeep",
+  "shopkeep",
   "wild_prize",
   "deadringer",
   -- "a_balatro_movie",


### PR DESCRIPTION
## Summary
Shopkeep gives a Coupon tag every other blind and a Voucher tag after defeating a boss blind. 
Unlock condition and blueprint compatibility fully working.