### PR TITLE
Bunco Cross-Mod: Removes Exotic Suits from tooltips when they are not discovered yet

### DIFF
--- a/utilities/cross-mod.lua
+++ b/utilities/cross-mod.lua
@@ -8,8 +8,8 @@ to_number = to_number or function(n)
 end
 
 -- Load modded suits
-if (SMODS.Mods["Bunco"] or {}).can_load then
-  local prefix = SMODS.Mods["Bunco"].prefix
+if next(SMODS.find_mod('Bunco')) then
+  local prefix = SMODS.find_mod('Bunco')[1].prefix or "bunc"
 
   table.insert(PB_UTIL.light_suits, prefix .. '_Fleurons')
   table.insert(PB_UTIL.dark_suits, prefix .. '_Halberds')

--- a/utilities/ui.lua
+++ b/utilities/ui.lua
@@ -303,6 +303,7 @@ end
 --- @return table
 function PB_UTIL.suit_tooltip(type)
   local suits = type == 'light' and PB_UTIL.light_suits or PB_UTIL.dark_suits
+
   local key = 'paperback_' .. type .. '_suits'
   local colours = {}
 
@@ -316,16 +317,25 @@ function PB_UTIL.suit_tooltip(type)
     for i = 1, #suits do
       local suit = suits[i]
 
-      colours[#colours + 1] = G.C.SUITS[suit] or G.C.IMPORTANT
-      line = line .. "{V:" .. i .. "}" .. localize(suit, 'suits_plural') .. "{}"
-
-      if i < #suits then
-        line = line .. ", "
+      -- Remove Bunco exotic suits if they are not revealed yet
+      if next(SMODS.find_mod("Bunco")) and not (G.GAME and G.GAME.Exotic) then
+        if suit == "bunc_Fleurons" or suit == "bunc_Halberds" then
+          suit = nil
+        end
       end
 
-      if #line > 30 then
-        text[#text + 1] = line
-        line = ""
+      if suit ~= nil then
+        colours[#colours + 1] = G.C.SUITS[suit] or G.C.IMPORTANT
+        line = line .. "{V:" .. i .. "}" .. localize(suit, 'suits_plural') .. "{}"
+
+        if i < #suits then
+          line = line .. ", "
+        end
+
+        if #line > 30 then
+          text[#text + 1] = line
+          line = ""
+        end
       end
     end
 


### PR DESCRIPTION
In the Bunco mod, any jokers that interact with exotic suits will not mention this in their descriptions until exotic suits are found in a run. E.g. with Cassette below:
<img width="1310" height="650" alt="image" src="https://github.com/user-attachments/assets/8bc84b2c-fc7e-43ff-8f5d-5901b463e227" />

This PR modifies the Paperback tooltip function to work similarly. This only affects Halberds and Fleurons, Paperback's new suits will work the same.