### PR TITLE
Compatibility: use `Blind:get_type()` instead of checking name

### DIFF
--- a/content/joker/langely.lua
+++ b/content/joker/langely.lua
@@ -10,7 +10,7 @@ SMODS.Joker {
   perishable_compat = true,
 
   calculate = function(self, card, context)
-    if context.end_of_round and context.main_eval and (G.GAME.blind.boss or G.GAME.blind.name == "Big Blind") then
+    if context.end_of_round and context.main_eval and (G.GAME.blind.boss or G.GAME.blind:get_type() == "Big") then
       local money = 0
 
       for _, v in ipairs(G.jokers.cards) do


### PR DESCRIPTION
For mods that add custom Small and Big Blinds.